### PR TITLE
Dark theme improvements

### DIFF
--- a/app/javascript/stats.js
+++ b/app/javascript/stats.js
@@ -14,7 +14,6 @@ window.initializeChart = async function(rawData, containerId) {
     labels: Object.keys(rawData),
     datasets: [{
       backgroundColor: getComputedStyle(canvas).getPropertyValue("--chart-background-color"),
-      borderColor: getComputedStyle(canvas).getPropertyValue("--chart-border-color"),
       data: Object.values(rawData)
     }]
   }
@@ -34,7 +33,8 @@ window.initializeChart = async function(rawData, containerId) {
         },
         y: {
           suggestedMax: 10,
-          beginAtZero: true
+          beginAtZero: true,
+          grid: {color: getComputedStyle(canvas).getPropertyValue("--chart-border-color")},
         }
       },
       plugins: {

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -8,6 +8,7 @@
 @import 'badges.css';
 @import 'code.css';
 @import 'diff.css';
+@import 'dark_prettify.css';
 @import 'ethical_ads.css';
 @import 'expandable-text.css';
 @import 'forum.css';

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -8,6 +8,7 @@
 @import 'badges.css';
 @import 'code.css';
 @import 'diff.css';
+@import 'dark_ace_editor.css';
 @import 'dark_prettify.css';
 @import 'ethical_ads.css';
 @import 'expandable-text.css';

--- a/app/javascript/stylesheets/code.css
+++ b/app/javascript/stylesheets/code.css
@@ -7,7 +7,7 @@ pre code {
 }
 pre, code {
   border-radius: 2px;
-  border: 1px solid #E6DDD6;
+  border: 1px solid var(--code-border-color);
 }
 pre {
   padding: 1em;

--- a/app/javascript/stylesheets/code.css
+++ b/app/javascript/stylesheets/code.css
@@ -7,15 +7,14 @@ pre code {
 }
 pre, code {
   border-radius: 2px;
-  border: 1px solid var(--code-border-color);
 }
 pre {
   padding: 1em;
 }
 .prettyprint {
   min-width: calc(100% - 6px);
-  background-color: white;
-  color: black;
+  background-color: var(--prettyprint-background-color);
+  color: var(--prettyprint-color);
 }
 .prettyprint.wrap {
   white-space: pre-wrap;
@@ -29,7 +28,7 @@ pre {
   max-height: calc(100vh - 54px);
   overflow-x: auto;
   border-radius: 2px;
-  border: 1px solid #E6DDD6;
+  border: 1px solid var(--code-container-border-color);
 }
 .code-container pre {
   border: 0;

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -131,6 +131,9 @@
     --alert-border-color: #A19000;
     --alert-text-color: white;
 
+    --chart-background-color: #606060;
+    --chart-border-color: #454545;
+
     --highlight-background-color: #550;
 
     --rating-icon-ok-border-color: rgb(135, 135, 33);

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -88,6 +88,10 @@
     --notice-background-color: #0E3041;
     --notice-text-color: white;
 
+    --alert-background-color: #3D3D00;
+    --alert-border-color: #A19000;
+    --alert-text-color: white;
+
     --highlight-background-color: #550;
 
     --rating-icon-ok-border-color: rgb(135, 135, 33);

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -38,6 +38,18 @@
   --chart-border-color: rgb(220,220,220);
 
   --highlight-background-color: #ffc;
+
+  --rating-icon-good-border-color: rgb(77, 166, 77);
+  --rating-icon-good-background-color: rgb(230, 242, 230);
+  --rating-icon-good-color: rgb(0, 128, 0);
+
+  --rating-icon-ok-border-color: rgb(211, 211, 77);
+  --rating-icon-ok-background-color: rgb(255, 255, 230);
+  --rating-icon-ok-color: rgb(192, 192, 0);
+
+  --rating-icon-bad-border-color: rgb(255, 77, 77);
+  --rating-icon-bad-background-color: rgb(255, 230, 230);
+  --rating-icon-bad-color: rgb(255, 0, 0);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -71,5 +83,17 @@
     --list-option-background-color-gradient-2: #222222;
 
     --highlight-background-color: #550;
+
+    --rating-icon-ok-border-color: rgb(135, 135, 33);
+    --rating-icon-ok-background-color: rgb(49, 49, 0);
+    --rating-icon-ok-color: rgb(255, 255, 70);
+  
+    --rating-icon-bad-border-color: rgb(155, 0, 0);
+    --rating-icon-bad-background-color: rgb(32, 0, 0);
+    --rating-icon-bad-color: rgb(255, 26, 26);
+  
+    --rating-icon-good-border-color: rgb(58, 124, 58);
+    --rating-icon-good-background-color: rgb(31, 49, 25);
+    --rating-icon-good-color: rgb(114, 255, 114);
   }    
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -42,6 +42,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    color-scheme: dark;
+
     --overall-background-color: #0A0A0A;
     --overall-text-color: white;
 

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -85,6 +85,9 @@
     --list-option-background-color-gradient-1: #111;
     --list-option-background-color-gradient-2: #222222;
 
+    --notice-background-color: #0E3041;
+    --notice-text-color: white;
+
     --highlight-background-color: #550;
 
     --rating-icon-ok-border-color: rgb(135, 135, 33);

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -18,6 +18,7 @@
   --inactive-item-background-color: #F5F5F5;
 
   --code-background-color: #F2E5E5;
+  --code-border-color: #E6DDD6;
 
   --user-content-background-color-gradient-1: #fcf1f1;
   --user-content-background-color-gradient-2: #FFF;
@@ -97,7 +98,8 @@
 
     --inactive-item-background-color: #333;
 
-    --code-background-color: black;
+    --code-background-color: #321919;
+    --code-border-color: #4C3B2E;
 
     --user-content-background-color-gradient-1: #2e1111;
     --user-content-background-color-gradient-2: #000;

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -75,6 +75,13 @@
   --diff-ins-strong-background: #9F9;
 
   --diff-block-info: gray;
+
+  --list-option-button-background-color: white;
+  --list-option-button-color: black;
+  --list-option-button-border-color: #BBB;
+
+  --list-option-button-background-color-gradient-1: white;
+  --list-option-button-background-color-gradient-2: #F6F6F6;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -152,5 +159,11 @@
     --diff-ins-strong-background: #1c7000;
 
     --diff-block-info: #60686C;
+
+    --list-option-button-background-color: #181a1b;
+    --list-option-button-color: #e8e6e3;
+    --list-option-button-border-color: #43494c;
+    --list-option-button-background-color-gradient-1: #232526;
+    --list-option-button-background-color-gradient-2: #181a1b;
   }
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -90,6 +90,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
+    scrollbar-color: #454a4d #202324;
 
     --overall-background-color: #0A0A0A;
     --overall-text-color: white;
@@ -117,8 +118,8 @@
     --list-option-background-color-gradient-1: #111;
     --list-option-background-color-gradient-2: #222222;
 
-   --list-option-hover-background-color-gradient-1: #1d1e1e;
-   --list-option-hover-background-color-gradient-2: #2a2c2d;
+    --list-option-hover-background-color-gradient-1: #1d1e1e;
+    --list-option-hover-background-color-gradient-2: #2a2c2d;
 
     --list-option-hover-box-shadow-top: #3a3a3a;
     --list-option-hover-box-shadow-bottom: #2a2c2d;

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -50,6 +50,9 @@
   --rating-icon-bad-border-color: rgb(255, 77, 77);
   --rating-icon-bad-background-color: rgb(255, 230, 230);
   --rating-icon-bad-color: rgb(255, 0, 0);
+
+  --expander-color: #670000;
+  --expander-background-color: #F2E5E5;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -95,5 +98,8 @@
     --rating-icon-good-border-color: rgb(58, 124, 58);
     --rating-icon-good-background-color: rgb(31, 49, 25);
     --rating-icon-good-color: rgb(114, 255, 114);
-  }    
+
+    --expander-color: #e95757;
+    --expander-background-color: #321919;
+  }
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -126,11 +126,11 @@
     --rating-icon-ok-border-color: rgb(135, 135, 33);
     --rating-icon-ok-background-color: rgb(49, 49, 0);
     --rating-icon-ok-color: rgb(255, 255, 70);
-  
+
     --rating-icon-bad-border-color: rgb(155, 0, 0);
     --rating-icon-bad-background-color: rgb(32, 0, 0);
     --rating-icon-bad-color: rgb(255, 26, 26);
-  
+
     --rating-icon-good-border-color: rgb(58, 124, 58);
     --rating-icon-good-background-color: rgb(31, 49, 25);
     --rating-icon-good-color: rgb(114, 255, 114);
@@ -149,6 +149,8 @@
 
     --diff-del-strong-background: #520000;
 
-    --diff-ins-strong-background: #diff-block-info: #60686C;
+    --diff-ins-strong-background: #1c7000;
+
+    --diff-block-info: #60686C;
   }
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -26,6 +26,12 @@
   --list-option-background-color-gradient-1: white;
   --list-option-background-color-gradient-2: #EEEEEE;
 
+  --list-option-hover-background-color-gradient-1: white;
+  --list-option-hover-background-color-gradient-2: #F6F6F6;
+
+  --list-option-hover-box-shadow-top: #DDDDDD;
+  --list-option-hover-box-shadow-bottom: #EEEEEE;
+
   --notice-background-color: #D9EDF7;
   --notice-border-color: #31708F;
   --notice-text-color: black;
@@ -99,6 +105,12 @@
 
     --list-option-background-color-gradient-1: #111;
     --list-option-background-color-gradient-2: #222222;
+
+   --list-option-hover-background-color-gradient-1: #1d1e1e;
+   --list-option-hover-background-color-gradient-2: #2a2c2d;
+
+    --list-option-hover-box-shadow-top: #3a3a3a;
+    --list-option-hover-box-shadow-bottom: #2a2c2d;
 
     --notice-background-color: #0E3041;
     --notice-text-color: white;

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -18,7 +18,6 @@
   --inactive-item-background-color: #F5F5F5;
 
   --code-background-color: #F2E5E5;
-  --code-border-color: #E6DDD6;
 
   --user-content-background-color-gradient-1: #fcf1f1;
   --user-content-background-color-gradient-2: #FFF;
@@ -79,9 +78,13 @@
   --list-option-button-background-color: white;
   --list-option-button-color: black;
   --list-option-button-border-color: #BBB;
-
   --list-option-button-background-color-gradient-1: white;
   --list-option-button-background-color-gradient-2: #F6F6F6;
+
+  --code-container-border-color: #E6DDD6;
+
+  --prettyprint-background-color: white;
+  --prettyprint-color: black;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -106,7 +109,6 @@
     --inactive-item-background-color: #333;
 
     --code-background-color: #321919;
-    --code-border-color: #4C3B2E;
 
     --user-content-background-color-gradient-1: #2e1111;
     --user-content-background-color-gradient-2: #000;
@@ -165,5 +167,10 @@
     --list-option-button-border-color: #43494c;
     --list-option-button-background-color-gradient-1: #232526;
     --list-option-button-background-color-gradient-2: #181a1b;
+
+    --code-container-border-color: #4c3b2e;
+
+    --prettyprint-background-color: #181a1b;
+    --prettyprint-color: #e8e6e3;
   }
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -53,6 +53,9 @@
 
   --expander-color: #670000;
   --expander-background-color: #F2E5E5;
+
+  --pagination-background-color: #F2E5E5;
+  --pagination-hover-background-color: #E2C5C5;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -108,5 +111,8 @@
 
     --expander-color: #e95757;
     --expander-background-color: #321919;
+
+    --pagination-background-color: #321919;
+    --pagination-hover-background-color: #452222;
   }
 }

--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -56,6 +56,18 @@
 
   --pagination-background-color: #F2E5E5;
   --pagination-hover-background-color: #E2C5C5;
+
+  --diff-del-background: #FEE;
+  --diff-del-color: #B00;
+
+  --diff-ins-background: #DFD;
+  --diff-ins-color: #080;
+
+  --diff-del-strong-background: #FCC;
+
+  --diff-ins-strong-background: #9F9;
+
+  --diff-block-info: gray;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -114,5 +126,15 @@
 
     --pagination-background-color: #321919;
     --pagination-hover-background-color: #452222;
+
+    --diff-del-background: #3D0000;
+    --diff-del-color: #FF4949;
+
+    --diff-ins-background: #124700;
+    --diff-ins-color: #6DFF6D;
+
+    --diff-del-strong-background: #520000;
+
+    --diff-ins-strong-background: #diff-block-info: #60686C;
   }
 }

--- a/app/javascript/stylesheets/dark_ace_editor.css
+++ b/app/javascript/stylesheets/dark_ace_editor.css
@@ -1,0 +1,40 @@
+@media (prefers-color-scheme: dark) {
+  #ace-editor.ace-tm {background-color: #181a1b; color: #e8e6e3; border-color: #43494c;}
+  #ace-editor.ace-tm .ace_indent-guide {opacity: 0.1;}
+  #ace-editor.ace-tm .ace_scroller {background-color: #181a1b;}
+  #ace-editor.ace-tm .ace_gutter {background: #202325; color: #c8c3bc;}
+  #ace-editor.ace-tm .ace_print-margin {background: #25282a;}
+  #ace-editor.ace-tm .ace_fold {background-color: #161d84;}
+  #ace-editor.ace-tm .ace_cursor {color: #e8e6e3;}
+  #ace-editor.ace-tm .ace_invisible {color: #c0bab2;}
+  #ace-editor.ace-tm .ace_storage, #ace-editor.ace-tm .ace_keyword {color: #337dff;}
+  #ace-editor.ace-tm .ace_constant {color: #f94448;}
+  #ace-editor.ace-tm .ace_constant.ace_buildin {color: #5e4ef6;}
+  #ace-editor.ace-tm .ace_constant.ace_language {color: #5a94f6;}
+  #ace-editor.ace-tm .ace_constant.ace_library {color: #65f96d;}
+  #ace-editor.ace-tm .ace_invalid {background-color: rgba(204, 0, 0, 0.1); color: #ff1a1a;}
+  #ace-editor.ace-tm .ace_support.ace_function {color: #99b0c9;}
+  #ace-editor.ace-tm .ace_support.ace_constant {color: #65f96d;}
+  #ace-editor.ace-tm .ace_support.ace_type, #ace-editor.ace-tm .ace_support.ace_class {color: #6f9cde;}
+  #ace-editor.ace-tm .ace_keyword.ace_operator {color: #9d9487;}
+  #ace-editor.ace-tm .ace_string {color: #83fb88;}
+  #ace-editor.ace-tm .ace_comment {color: #7fb89c;}
+  #ace-editor.ace-tm .ace_comment.ace_doc {color: #339cff;}
+  #ace-editor.ace-tm .ace_comment.ace_doc.ace_tag {color: #84a6c1;}
+  #ace-editor.ace-tm .ace_constant.ace_numeric {color: #5190ff;}
+  #ace-editor.ace-tm .ace_variable {color: #70c0d0;}
+  #ace-editor.ace-tm .ace_xml-pe {color: #aaa398;}
+  #ace-editor.ace-tm .ace_entity.ace_name.ace_function {color: #6ba1ff;}
+  #ace-editor.ace-tm .ace_heading {color: #1e6fff;}
+  #ace-editor.ace-tm .ace_list {color: #f94cd2;}
+  #ace-editor.ace-tm .ace_meta.ace_tag {color: #77b0ff;}
+  #ace-editor.ace-tm .ace_string.ace_regex {color: #ff1a1a;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_selection {background: #2d3133;}
+  #ace-editor.ace-tm.ace_multiselect .ace_selection.ace_start {box-shdow: 0 0 3px 0px #181a1b;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_step {background: #989900;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_stack {background: #5d8817;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_bracket {margin: -1px 0 0 -1px; border: 1px solid #42474a;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_active-line {background: rgba(0, 0, 0, 0.07);}
+  #ace-editor.ace-tm .ace_gutter-active-line {background-color : #2c2f31;}
+  #ace-editor.ace-tm .ace_marker-layer .ace_selected-word {background: #191c1d; border: 1px solid #0a0a6e;}
+}

--- a/app/javascript/stylesheets/dark_prettify.css
+++ b/app/javascript/stylesheets/dark_prettify.css
@@ -1,7 +1,6 @@
 @media (prefers-color-scheme: dark) {
   .code-container pre.prettyprint {
-    border: 1px solid #9d9488;
-    color: #e8e6e3;
+    border: 1px solid #52585c;
   }
   .prettyprint li.L1, .prettyprint li.L3, .prettyprint li.L5, .prettyprint li.L7, .prettyprint li.L9 {
     background: #222426;

--- a/app/javascript/stylesheets/dark_prettify.css
+++ b/app/javascript/stylesheets/dark_prettify.css
@@ -1,0 +1,21 @@
+@media (prefers-color-scheme: dark) {
+  .code-container pre.prettyprint {
+    border: 1px solid #9d9488;
+    color: #e8e6e3;
+  }
+  .prettyprint li.L1, .prettyprint li.L3, .prettyprint li.L5, .prettyprint li.L7, .prettyprint li.L9 {
+    background: #222426;
+  }
+  .prettyprint .pln {color: #e8e6e3;}
+  .prettyprint .str {color: #6dff6d;}
+  .prettyprint .kwd {color: #7aabff;}
+  .prettyprint .com {color: #ff6d6d;}
+  .prettyprint .typ {color: #ff85ff;}
+  .prettyprint .lit {color: #85ffff;}
+  .prettyprint .clo,.prettyprint .opn,.prettyprint .pun {color: #ffff85;}
+  .prettyprint .tag {color: #7aabff;}
+  .prettyprint .atn {color: #ff85ff;}
+  .prettyprint .atv {color: #6dff6d;}
+  .prettyprint .var,.prettyprint .dec {color: #ff85ff;}
+  .prettyprint .fun{color:#ff0000;}
+}

--- a/app/javascript/stylesheets/diff.css
+++ b/app/javascript/stylesheets/diff.css
@@ -7,15 +7,15 @@
 .diff ul{background:#fff;overflow:auto;font-size:13px;list-style:none;margin:0;padding:0;display:table;width:100%;}
 .diff del, .diff ins{display:block;text-decoration:none;}
 .diff li{padding:0; display:table-row;margin: 0;height:1em;}
-.diff li.ins{background:#dfd; color:#080}
-.diff li.del{background:#fee; color:#b00}
+.diff li.ins{background:var(--diff-ins-background); color:var(--diff-ins-color)}
+.diff li.del{background:var(--diff-del-background); color:var(--diff-del-color)}
 .diff li:hover{background:#ffc}
 /* try 'whitespace:pre;' if you don't want lines to wrap */
 .diff del, .diff ins, .diff span{white-space:pre;font-family:courier;}
-.diff del strong{font-weight:normal;background:#fcc;}
-.diff ins strong{font-weight:normal;background:#9f9;}
+.diff del strong{font-weight:normal;background:var(--diff-del-strong-background);}
+.diff ins strong{font-weight:normal;background:var(--diff-ins-strong-background);}
 .diff li.diff-comment { display: none; }
-.diff li.diff-block-info { background: none repeat scroll 0 0 gray; }
+.diff li.diff-block-info { background: none repeat scroll 0 0 var(--diff-block-info); }
 
 .diff del, .diff ins, .diff span{font-family:monospace;}
 

--- a/app/javascript/stylesheets/expandable-text.css
+++ b/app/javascript/stylesheets/expandable-text.css
@@ -1,9 +1,9 @@
 .expander {
   cursor: pointer;
   display: block;
-  color: #670000;
+  color: var(--expander-color);
   border-radius: 3px;
-  background-color: #F2E5E5;
+  background-color: var(--expander-background-color);
   position: absolute;
   width: 20px;
   height: 20px;

--- a/app/javascript/stylesheets/forum.css
+++ b/app/javascript/stylesheets/forum.css
@@ -114,19 +114,19 @@ a.discussion-title, .notification-list-item a {
   top: -1px;
 }
 .rating-icon-good {
-  border-color: rgb(77,166,77);
-  background-color: rgb(230, 242, 230);
-  color: rgb(0, 128, 0);
+  border-color: var(--rating-icon-good-border-color);
+  background-color: var(--rating-icon-good-background-color);
+  color: var(--rating-icon-good-color)
 }
 .rating-icon-ok {
-  border-color: rgb(211, 211, 77);
-  background-color: rgb(255, 255, 230);
-  color: rgb(192, 192, 0);
+  border-color: var(--rating-icon-ok-border-color);
+  background-color: var(--rating-icon-ok-background-color);
+  color: var(--rating-icon-ok-color)
 }
 .rating-icon-bad {
-  border-color: rgb(255, 77, 77);
-  background-color: rgb(255, 230, 230);
-  color: rgb(255, 0, 0);
+  border-color: var(--rating-icon-bad-border-color);
+  background-color: var(--rating-icon-bad-background-color);
+  color: var(--rating-icon-bad-color)
 }
 .discussion-meta-item-script-name {
   overflow: hidden;

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -278,7 +278,7 @@ label.subselection-radio-title {
 }
 .pagination > *, .script-list + .pagination > *, .user-list + .pagination > * {
   display: inline-block;
-  background-color: #F2E5E5;
+  background-color: var(--pagination-background-color);
   padding: 0.5em;
   border-radius: 5px;
   text-decoration: none;
@@ -294,7 +294,7 @@ label.subselection-radio-title {
   background-color: transparent;
 }
 .pagination > a:hover, .pagination > a:focus {
-  background-color: #e2c5c5;
+  background-color: var(--pagination-hover-background-color);
 }
 @media screen and (max-width: 400px) {
   .pagination, .script-list + .pagination, .user-list + .pagination {

--- a/app/javascript/stylesheets/list_options.css
+++ b/app/javascript/stylesheets/list_options.css
@@ -20,9 +20,9 @@
   display: block;
 }
 .list-option-group a:hover, .list-option-group a:focus {
-  background: linear-gradient(white, #F6F6F6);
+  background: linear-gradient(var(--list-option-hover-background-color-gradient-1), var(--list-option-hover-background-color-gradient-2));
   text-decoration: none;
-  box-shadow: inset 0 -1px #DDDDDD, inset 0 1px #EEEEEE;
+  box-shadow: inset 0 -1px var(--list-option-hover-box-shadow-top), inset 0 1px var(--list-option-hover-box-shadow-bottom);
 }
 .list-option-group .list-current {
   border-left: 7px solid #800;

--- a/app/javascript/stylesheets/list_options.css
+++ b/app/javascript/stylesheets/list_options.css
@@ -42,16 +42,16 @@
 
 .list-option-button {
   display: block;
-  background-color: white;
+  background-color: var(--list-option-button-background-color);
   text-align: center;
   text-decoration: none;
-  color: black !important;
-  border: 1px solid #BBBBBB;
+  color: var(--list-option-button-color) !important;
+  border: 1px solid var(--list-option-button-border-color);
   padding: 0.5em;
   font-weight: bold;
 }
 .list-option-button:hover, .list-option-button:focus {
-  background: linear-gradient(white, #F6F6F6);
+  background: linear-gradient(var(--list-option-button-background-color-gradient-1), var(--list-option-button-background-color-gradient-2));
   text-decoration: none;
 }
 


### PR DESCRIPTION
This PR improves the dark mode of greasyfork:

* Replaced hard-coded light theme colors with CSS variables.
* Added these variables to the `colors.css` file and defined corresponding dark theme variants.
* Added `color-scheme: dark;` and `scrollbar-color: #454a4d #202324;` to `colors.css`. While functional, this might not be the most appropriate location, I'm open to suggestions.
* Created custom styles for Prettify and Ace Editor into their own CSS files. I'm not certain this is the optimal structure, feedback is welcome.

I was not able to build GreasyFork itself, instead, I generated and replaced the application-css file and tested the changes on static site copies and created test pages for chart.js to verify the CSS adjustments.

If these changes are too broad and should be split into smaller PRs, let me know and I can restructure them accordingly.

This fixes #1443 