### PR TITLE
Add EinkBro to the Mobile (iOS) supported browsers list

### DIFF
--- a/app/views/help/_installing.html.erb
+++ b/app/views/help/_installing.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <div id="ios-browser-list" class="browser-list">
-    <%= it('home.ios_browsers.browser_list_html', safari_tampermonkey_link: 'https://www.tampermonkey.net/?browser=safari', safari_userscripts_link: 'https://apps.apple.com/app/userscripts/id1463298887', gear_link: 'https://gear4.app/', teak_link: 'https://teakbrowser.app/') %>
+    <%= it('home.ios_browsers.browser_list_html', safari_tampermonkey_link: 'https://www.tampermonkey.net/?browser=safari', safari_userscripts_link: 'https://apps.apple.com/app/userscripts/id1463298887', gear_link: 'https://gear4.app/', teak_link: 'https://teakbrowser.app/', einkbro_link: 'https://apps.apple.com/app/einkbro/id6792317757') %>
   </div>
 </section>
 

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -553,6 +553,7 @@ bg:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} или %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (не е необходимо нищо допълнително)
           <li>%{teak_link:Teak}: (не е необходимо нищо допълнително)
+          <li>%{einkbro_link:EinkBro}: (не е необходимо нищо допълнително)
           </ul>
     installing_step2_header: "Стъпка 2: инсталирайте потребителски скрипт"
     installing_step2_caption: "Бутон за инсталиране на скрипта"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -766,6 +766,7 @@ en:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} or %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (no additional software required)
           <li>%{teak_link:Teak}: (no additional software required)
+          <li>%{einkbro_link:EinkBro}: (no additional software required)
         </ul>
     # header for step 2 - how to install a user script
     installing_step2_header: "Step 2: install a user script"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -546,6 +546,7 @@ ko:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} 또는 %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (추가 소프트웨어 필요 없음)
           <li>%{teak_link:Teak}: (추가 소프트웨어 필요 없음)
+          <li>%{einkbro_link:EinkBro}: (추가 소프트웨어 필요 없음)
           </ul>
     installing_step2_header: "2단계: 유저 스크립트 설치"
     installing_step2_caption: "유저 스크립트 설치 버튼"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -557,6 +557,7 @@ nl:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} of %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (geen aanvullende software vereist)
           <li>%{teak_link:Teak}: (geen aanvullende software vereist)
+          <li>%{einkbro_link:EinkBro}: (geen aanvullende software vereist)
           </ul>
     installing_step2_header: "Stap 2: installeer een gebruikersscript"
     installing_step2_caption: "De installatieknop bij een gebruikersscript"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -560,6 +560,7 @@ pt-BR:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} ou %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (nenhum software adicional necessário)
           <li>%{teak_link:Teak}: (nenhum software adicional necessário)
+          <li>%{einkbro_link:EinkBro}: (nenhum software adicional necessário)
           </ul>
     installing_step2_header: "Passo 2: instalar um script de usuário"
     installing_step2_caption: "Um botão de instalação de um script de usuário"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -561,6 +561,7 @@ ru:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} или %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (дополнительного ПО не требуется)
           <li>%{teak_link:Teak}: (дополнительного ПО не требуется)
+          <li>%{einkbro_link:EinkBro}: (дополнительного ПО не требуется)
           </ul>
     installing_step2_header: "Шаг 2: установить скрипт"
     installing_step2_caption: "Кнопка установки скрипта"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -561,6 +561,7 @@ sk:
           <li>Safari: %{safari_tampermonkey_link:Tampermonkey} alebo %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}: (nie je potrebný žiadny ďalší softvér)
           <li>%{teak_link:Teak}: (nie je potrebný žiadny ďalší softvér)
+          <li>%{einkbro_link:EinkBro}: (nie je potrebný žiadny ďalší softvér)
           </ul>
     installing_step2_header: "2. krok: Inštalácia používateľského skriptu"
     installing_step2_caption: "Tlačidlo pre nainštalovanie používateľského skriptu"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -543,6 +543,7 @@ zh-CN:
           <li>Safari：%{safari_tampermonkey_link:Tampermonkey} 或 %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}：（无须安装额外软件）
           <li>%{teak_link:Teak}：（无须安装额外软件）
+          <li>%{einkbro_link:EinkBro}：（无须安装额外软件）
           </ul>
     installing_step2_header: "第 2 步：安装一个用户脚本"
     installing_step2_caption: "用户脚本的安装按钮"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -521,6 +521,7 @@ zh-TW:
           <li>Safari：%{safari_tampermonkey_link:Tampermonkey} 或 %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}：（不需要其他軟體）
           <li>%{teak_link:Teak}：（不需要其他軟體）
+          <li>%{einkbro_link:EinkBro}：（不需要其他軟體）
           </ul>
     installing_step2_header: "第二步：安裝使用者腳本"
     installing_step2_caption: "使用者腳本的安裝按鈕"


### PR DESCRIPTION
Follow-up to #1550: [EinkBro](https://github.com/plateaukao/einkbro-ios) is now also available for iOS with built-in userscript support ([App Store](https://apps.apple.com/app/einkbro/id6792317757)). This adds it to the **Mobile (iOS)** supported browsers list, directly after Teak, with the same "(no additional software required)" note as Gear and Teak.

### Changes
- `app/views/help/_installing.html.erb` — supply the `einkbro_link` URL (`https://apps.apple.com/app/einkbro/id6792317757`) to the iOS browser list translation call. The region-free App Store URL is used, matching the existing Userscripts link convention.
- Added `<li>%{einkbro_link:EinkBro}: (no additional software required)` after the Teak entry in every locale that has a localized iOS list (`bg, en, ko, nl, pt-BR, ru, sk, zh-CN, zh-TW`), reusing each locale's existing translation of the parenthetical from its Gear/Teak entries.

The remaining locales have no `ios_browsers.browser_list_html` of their own and fall back to `en.yml`, so they pick up EinkBro automatically.

All modified YAML files were verified to parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)