### PR TITLE
Enable Portuguese (pt) UI locale

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,6 +1,6 @@
 I18n.config.enforce_available_locales = true
 # locales good enough to link to
-Rails.application.config.available_locales = %w[ar be bg ckb cs da de el en eo es es-419 fi fil fr fr-CA he hr hu id it ja ka ko mr nb nl pl pt-BR ro ru sk sr sv th tr uk ug vi zh-CN zh-TW]
+Rails.application.config.available_locales = %w[ar be bg ckb cs da de el en eo es es-419 fi fil fr fr-CA he hr hu id it ja ka ko mr nb nl pl pt pt-BR ro ru sk sr sv th tr uk ug vi zh-CN zh-TW]
 Rails.application.config.help_translate_url = 'https://github.com/greasyfork-org/greasyfork/wiki/Translating-Greasy-Fork'
 Rails.application.config.i18n.fallbacks = [:en]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   get '/:locale', constraints: { locale: /fr-ca|pt-br|zh-cn|zh-tw/ }, to: lowercase_locale_redirector
   get '/:locale/*', constraints: { locale: /fr-ca|pt-br|zh-cn|zh-tw/ }, to: lowercase_locale_redirector
 
-  scope '(:locale)', locale: /ar|be|bg|ckb|cs|da|de|el|en|es|es-419|fi|fil|fr|fr-CA|he|hr|hu|id|it|ja|ka|ko|mr|nb|nl|eo|pl|pt-BR|ro|ru|sk|sr|sv|th|tr|uk|ug|vi|zh-CN|zh-TW/ do
+  scope '(:locale)', locale: /ar|be|bg|ckb|cs|da|de|el|en|es|es-419|fi|fil|fr|fr-CA|he|hr|hu|id|it|ja|ka|ko|mr|nb|nl|eo|pl|pt|pt-BR|ro|ru|sk|sr|sv|th|tr|uk|ug|vi|zh-CN|zh-TW/ do
     get '/users', to: 'users#index', as: 'users'
     get '/users/webhook-info', to: 'users#webhook_info', as: 'user_webhook_info'
     post 'users/webhook-info', to: 'users#webhook_info'


### PR DESCRIPTION
Enable the existing Portuguese (pt) translation as a selectable Greasy Fork UI locale.

The Portuguese translation is already present in the repository as config/locales/pt.yml, but pt was not included in the UI locale whitelist or the localized route constraint.

Changes
Add pt to Rails.application.config.available_locales.
Add pt to the localized route constraint in config/routes.rb.
Notes

The existing locale system tests already iterate over every entry in Rails.application.config.available_locales, so enabling pt will include it in the same coverage as the other UI locales.

The Portuguese translation has also undergone a full QA pass against the current English source on Transifex.