### PR TITLE
Improve README and contributor onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,101 @@
-[Greasy Fork](https://greasyfork.org) is an online repository of user scripts and user styles.
+<div align="center">
 
-## Help
+<a href="https://greasyfork.org">
+  <img src="app/javascript/images/blacklogo96.png" width="96" height="96" alt="Greasy Fork logo">
+</a>
 
-Post in the [Greasy Forum](https://greasyfork.org/discussions/) for help with Greasy Fork, user scripts, user script managers, or related.
+# Greasy Fork
+
+**An open-source repository for user scripts and user styles.**
+
+[Website](https://greasyfork.org) ·
+[Forum](https://greasyfork.org/discussions/) ·
+[Issues](https://github.com/greasyfork-org/greasyfork/issues) ·
+[Contributing](https://github.com/greasyfork-org/greasyfork/wiki/Contributing-code) ·
+[Translations](https://github.com/greasyfork-org/greasyfork/wiki/Translating-Greasy-Fork)
+
+</div>
+
+---
+
+## About
+
+[Greasy Fork](https://greasyfork.org) is an open-source platform for discovering, installing, publishing, and discussing user scripts and user styles.
+
+This repository contains the application that powers Greasy Fork.
+
+### What Greasy Fork provides
+
+| Area | Description |
+| --- | --- |
+| **Discovery** | Browse and search user scripts and user styles for the websites you use. |
+| **Publishing** | Publish, update, synchronize, and manage scripts. |
+| **Community** | Discuss scripts, provide feedback, and interact with authors and other users. |
+| **Moderation** | Report content and provide moderators with tools for reviewing and managing it. |
+| **Localization** | Use Greasy Fork in multiple languages maintained by community translators. |
+| **Integrations** | Synchronize scripts from external sources and use webhook-based updates. |
+
+## Technology
+
+Greasy Fork is primarily a Ruby on Rails application with a JavaScript frontend.
+
+| Area | Technologies |
+| --- | --- |
+| **Backend** | Ruby, Ruby on Rails |
+| **Frontend** | Turbo, Vite, JavaScript |
+| **Database** | MySQL / MariaDB |
+| **Background jobs** | Sidekiq, Redis |
+| **Search** | Searchkick, Elasticsearch |
+| **Testing** | Minitest, Capybara, Selenium |
+| **Code editor** | Ace |
+| **Charts** | Chart.js |
+| **Localization** | Rails I18n, Transifex |
+
+Exact dependency versions are defined in [`Gemfile`](Gemfile) and [`package.json`](package.json).
+
+## Translations
+
+Greasy Fork is available in multiple languages thanks to community translators.
+
+English is the source locale. Translation resources are stored under [`config/locales`](config/locales), and the repository is configured to work with Transifex using [`.tx/config`](.tx/config).
+
+To contribute a new translation or improve an existing one, see:
+
+**[Translating Greasy Fork →](https://github.com/greasyfork-org/greasyfork/wiki/Translating-Greasy-Fork)**
 
 ## Contributing
 
-Greasy Fork welcomes contributions. Learn about [running Greasy Fork locally](https://github.com/JasonBarnabe/greasyfork/wiki/Running-Greasy-Fork-locally) and [contributing code](https://github.com/JasonBarnabe/greasyfork/wiki/Contributing-code).
+Contributions to Greasy Fork are welcome.
 
-## Donations
+For development environment setup and instructions on running Greasy Fork locally, see:
 
-If you like Greasy Fork, consider making a donation to help pay for hosting. Suggested amount is $10.
+**[Running Greasy Fork locally →](https://github.com/greasyfork-org/greasyfork/wiki/Running-Greasy-Fork-locally)**
 
-* [Donate via Stripe](https://donate.stripe.com/aEU03m025575fMk7ss)
-* [Donate by PayPal or credit card](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=jason.barnabe@gmail.com&item_name=Contribution+for+Greasy+Fork)
+Before submitting code changes, also see the [contributing code guide](https://github.com/greasyfork-org/greasyfork/wiki/Contributing-code).
+
+Other ways to contribute include:
+
+- browsing and investigating [existing issues](https://github.com/greasyfork-org/greasyfork/issues);
+- reviewing [open pull requests](https://github.com/greasyfork-org/greasyfork/pulls);
+- helping [translate Greasy Fork](https://github.com/greasyfork-org/greasyfork/wiki/Translating-Greasy-Fork).
+
+## Help and community
+
+For help with Greasy Fork, user scripts, user script managers, or related topics, visit the:
+
+**[Greasy Fork Forum →](https://greasyfork.org/discussions/)**
+
+Development discussions and existing bug reports can also be found in the project's [GitHub issues](https://github.com/greasyfork-org/greasyfork/issues).
+
+## Support Greasy Fork
+
+Greasy Fork is free and open-source software.
+
+If you find it useful, consider making a donation to help cover hosting costs. The suggested contribution is **$10**.
+
+- [Donate via Stripe](https://donate.stripe.com/aEU03m025575fMk7ss)
+- [Donate via PayPal or credit card](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=jason.barnabe@gmail.com&item_name=Contribution+for+Greasy+Fork)
 
 ## License
 
-Greasy Fork is licensed under the [GPLv3](https://github.com/JasonBarnabe/greasyfork/blob/master/COPYING).
+Greasy Fork is licensed under the [GNU General Public License v3.0](COPYING).


### PR DESCRIPTION
## Summary

Improve the README as a concise entry point for users and contributors while keeping detailed development documentation in the existing wiki.

## Changes

- Add the existing Greasy Fork logo and quick links to the website, forum, issues, contribution guide, and translation guide.
- Add a short overview of Greasy Fork's main capabilities.
- Document the high-level technology stack.
- Link to the existing "Running Greasy Fork locally" wiki page instead of duplicating local setup instructions.
- Clarify how translations are stored and synchronized with Transifex.
- Update repository links that previously pointed to the older `JasonBarnabe/greasyfork` location.
- Preserve the existing help, donation, and GPLv3 information in a clearer structure.

## Why

The current README provides only a short project description and a few links.

This update makes it a more useful project entry point while leaving detailed setup and development instructions in the wiki as the single source of truth.

## Validation

- Verified the technology and translation information against the current repository configuration and dependency files.
- Verified that the branch differs from `main` only in `README.md`.
- Detailed local development instructions are intentionally left in the existing wiki.

Documentation-only change; no runtime code was modified.