### PR TITLE
Improve keyboard and screen reader accessibility

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,12 @@ module ApplicationHelper
     tag.span(id: name) { link_to('§', { anchor: name }, { class: 'self-link' }) + text }
   end
 
+  def list_option(content, current: false)
+    html_options = { class: "list-option#{' list-current' if current}" }
+    html_options[:aria] = { current: 'true' } if current
+    tag.li(**html_options) { content }
+  end
+
   # Translates an array of keys and returns a hash.
   def translate_keys(keys)
     h = {}

--- a/app/helpers/discussion_helper.rb
+++ b/app/helpers/discussion_helper.rb
@@ -153,6 +153,8 @@ module DiscussionHelper
              label
            end
 
-    tag.li(class: "list-option#{' list-current' unless is_link}") { text }
+    html_options = { class: "list-option#{' list-current' unless is_link}" }
+    html_options[:aria] = { current: 'true' } unless is_link
+    tag.li(**html_options) { text }
   end
 end

--- a/app/helpers/discussion_helper.rb
+++ b/app/helpers/discussion_helper.rb
@@ -153,8 +153,6 @@ module DiscussionHelper
              label
            end
 
-    html_options = { class: "list-option#{' list-current' unless is_link}" }
-    html_options[:aria] = { current: 'true' } unless is_link
-    tag.li(**html_options) { text }
+    list_option(text, current: !is_link)
   end
 end

--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -6,7 +6,7 @@ module ScriptsHelper
   def script_tab_link(path, label, additional_current_check: false)
     label = "<span>#{h label}</span>".html_safe
 
-    return "<li class=\"current\">#{label}</li>".html_safe if current_page?(path) || additional_current_check
+    return "<li class=\"current\" aria-current=\"page\">#{label}</li>".html_safe if current_page?(path) || additional_current_check
 
     "<li>#{link_to(label, path, rel: (path.include?('version=') ? :nofollow : nil))}</li>".html_safe
   end
@@ -35,7 +35,9 @@ module ScriptsHelper
     else
       l = link_to label, by_site_scripts_path(sort: sort_param_to_use, site:, set:, q: params[:q].presence, language:, filter_locale:, by:, **advanced_search_params), rel:
     end
-    tag.li(class: "list-option#{' list-current' unless is_link}") { l }
+    html_options = { class: "list-option#{' list-current' unless is_link}" }
+    html_options[:aria] = { current: 'true' } unless is_link
+    tag.li(**html_options) { l }
   end
 
   def script_applies_to_list_contents(script)

--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -152,6 +152,7 @@ module ScriptsHelper
       rv[operator_param] = params[operator_param] if params[operator_param].present?
       rv[:tz] ||= params[:tz] if options[:type] == :datetime && (!exclude_blank || params[:tz].present?)
     end
+
     rv
   end
 

--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -35,9 +35,7 @@ module ScriptsHelper
     else
       l = link_to label, by_site_scripts_path(sort: sort_param_to_use, site:, set:, q: params[:q].presence, language:, filter_locale:, by:, **advanced_search_params), rel:
     end
-    html_options = { class: "list-option#{' list-current' unless is_link}" }
-    html_options[:aria] = { current: 'true' } unless is_link
-    tag.li(**html_options) { l }
+    list_option(l, current: !is_link)
   end
 
   def script_applies_to_list_contents(script)
@@ -154,7 +152,6 @@ module ScriptsHelper
       rv[operator_param] = params[operator_param] if params[operator_param].present?
       rv[:tz] ||= params[:tz] if options[:type] == :datetime && (!exclude_blank || params[:tz].present?)
     end
-
     rv
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -44,7 +44,9 @@ module UsersHelper
              label
            end
 
-    tag.li(class: "list-option#{' list-current' unless is_link}") { text }
+    html_options = { class: "list-option#{' list-current' unless is_link}" }
+    html_options[:aria] = { current: 'true' } unless is_link
+    tag.li(**html_options) { text }
   end
 
   def render_user_text(user, user_id)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -44,9 +44,7 @@ module UsersHelper
              label
            end
 
-    html_options = { class: "list-option#{' list-current' unless is_link}" }
-    html_options[:aria] = { current: 'true' } unless is_link
-    tag.li(**html_options) { text }
+    list_option(text, current: !is_link)
   end
 
   def render_user_text(user, user_id)

--- a/app/javascript/header.js
+++ b/app/javascript/header.js
@@ -1,5 +1,50 @@
 import onload from '~/onload'
 
-let toggleMobileNav = () => { document.querySelector("#mobile-nav nav").classList.toggle("collapsed") }
+onload(() => {
+  const opener = document.querySelector('.mobile-nav-opener')
+  const menu = document.querySelector('#mobile-nav nav')
+  if (!opener || !menu) {
+    return
+  }
 
-onload(() => document.querySelector(".mobile-nav-opener")?.addEventListener("click", toggleMobileNav))
+  if (!menu.id) {
+    menu.id = 'mobile-nav-menu'
+  }
+
+  const siteLabel = document.querySelector('#site-name-text h1')?.textContent.trim()
+  opener.setAttribute('role', 'button')
+  opener.setAttribute('tabindex', '0')
+  opener.setAttribute('aria-controls', menu.id)
+  opener.setAttribute('aria-expanded', 'false')
+  if (siteLabel) {
+    opener.setAttribute('aria-label', siteLabel)
+  }
+
+  const setExpanded = (expanded) => {
+    menu.classList.toggle('collapsed', !expanded)
+    opener.setAttribute('aria-expanded', expanded.toString())
+  }
+
+  const toggle = () => setExpanded(opener.getAttribute('aria-expanded') !== 'true')
+  opener.addEventListener('click', toggle)
+  opener.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && opener.getAttribute('aria-expanded') === 'true') {
+      event.preventDefault()
+      setExpanded(false)
+      return
+    }
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+    event.preventDefault()
+    toggle()
+  })
+  menu.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') {
+      return
+    }
+    event.preventDefault()
+    setExpanded(false)
+    opener.focus()
+  })
+})

--- a/app/javascript/sidebar.js
+++ b/app/javascript/sidebar.js
@@ -1,16 +1,58 @@
 import onload from '~/onload'
 
-onload(function() {
-  if (document.querySelector(".close-sidebar")) {
-    document.querySelector(".close-sidebar").addEventListener("click", function() {
-      document.querySelector(".sidebar").classList.add("collapsed");
-      document.querySelector(".open-sidebar").classList.add("sidebar-collapsed");
-    });
+function addKeyboardActivation(element, action) {
+  element.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+    event.preventDefault()
+    action()
+  })
+}
+
+onload(() => {
+  const sidebar = document.querySelector('.sidebar')
+  const openButton = document.querySelector('.open-sidebar')
+  const closeButton = document.querySelector('.close-sidebar')
+  if (!sidebar || !openButton || !closeButton) {
+    return
   }
-  if (document.querySelector(".open-sidebar")) {
-    document.querySelector(".open-sidebar").addEventListener("click", function() {
-      document.querySelector(".sidebar").classList.remove("collapsed");
-      document.querySelector(".open-sidebar").classList.remove("sidebar-collapsed");
-    });
+
+  if (!sidebar.id) {
+    sidebar.id = 'listing-options-sidebar'
   }
-});
+
+  const label = closeButton.querySelector('.sidebar-title')?.textContent.trim()
+  for (const control of [openButton, closeButton]) {
+    control.setAttribute('role', 'button')
+    control.setAttribute('tabindex', '0')
+    control.setAttribute('aria-controls', sidebar.id)
+    control.setAttribute('aria-expanded', 'false')
+    if (label && !control.hasAttribute('aria-label')) {
+      control.setAttribute('aria-label', label)
+    }
+  }
+
+  const setExpanded = (expanded, focusTarget) => {
+    sidebar.classList.toggle('collapsed', !expanded)
+    openButton.classList.toggle('sidebar-collapsed', !expanded)
+    openButton.setAttribute('aria-expanded', expanded.toString())
+    closeButton.setAttribute('aria-expanded', expanded.toString())
+    focusTarget?.focus()
+  }
+
+  const open = () => setExpanded(true, closeButton)
+  const close = () => setExpanded(false, openButton)
+
+  openButton.addEventListener('click', open)
+  closeButton.addEventListener('click', close)
+  addKeyboardActivation(openButton, open)
+  addKeyboardActivation(closeButton, close)
+  sidebar.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') {
+      return
+    }
+    event.preventDefault()
+    close()
+  })
+})

--- a/app/javascript/sidebar.js
+++ b/app/javascript/sidebar.js
@@ -38,7 +38,11 @@ onload(() => {
     openButton.classList.toggle('sidebar-collapsed', !expanded)
     openButton.setAttribute('aria-expanded', expanded.toString())
     closeButton.setAttribute('aria-expanded', expanded.toString())
-    ;(expanded ? closeButton : openButton).focus()
+    if (expanded) {
+      closeButton.focus()
+    } else {
+      openButton.focus()
+    }
   }
 
   const openSidebar = () => setExpanded(true)

--- a/app/javascript/sidebar.js
+++ b/app/javascript/sidebar.js
@@ -33,26 +33,26 @@ onload(() => {
     }
   }
 
-  const setExpanded = (expanded, focusTarget) => {
+  const setExpanded = (expanded) => {
     sidebar.classList.toggle('collapsed', !expanded)
     openButton.classList.toggle('sidebar-collapsed', !expanded)
     openButton.setAttribute('aria-expanded', expanded.toString())
     closeButton.setAttribute('aria-expanded', expanded.toString())
-    focusTarget?.focus()
+    ;(expanded ? closeButton : openButton).focus()
   }
 
-  const open = () => setExpanded(true, closeButton)
-  const close = () => setExpanded(false, openButton)
+  const openSidebar = () => setExpanded(true)
+  const closeSidebar = () => setExpanded(false)
 
-  openButton.addEventListener('click', open)
-  closeButton.addEventListener('click', close)
-  addKeyboardActivation(openButton, open)
-  addKeyboardActivation(closeButton, close)
+  openButton.addEventListener('click', openSidebar)
+  closeButton.addEventListener('click', closeSidebar)
+  addKeyboardActivation(openButton, openSidebar)
+  addKeyboardActivation(closeButton, closeSidebar)
   sidebar.addEventListener('keydown', (event) => {
     if (event.key !== 'Escape') {
       return
     }
     event.preventDefault()
-    close()
+    closeSidebar()
   })
 })

--- a/app/javascript/stylesheets/header.css
+++ b/app/javascript/stylesheets/header.css
@@ -90,7 +90,7 @@ nav nav li a {
   display: block;
   padding: 5px 15px;
 }
-nav a:hover + nav, nav nav:hover, nav a:focus + nav {
+nav a:hover + nav, nav nav:hover, nav a:focus + nav, nav .with-submenu:focus-within > nav {
   display: block;
 }
 .with-submenu {
@@ -157,6 +157,10 @@ nav .with-submenu > a::after {
   top: 0;
   font-size: 8.3vw;
   padding: 0 2vw;
+}
+.mobile-nav-opener:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 #mobile-nav .collapsed {
   display: none;

--- a/app/javascript/stylesheets/sidebar.css
+++ b/app/javascript/stylesheets/sidebar.css
@@ -15,6 +15,10 @@
 .close-sidebar, .open-sidebar {
   cursor: pointer;
 }
+.close-sidebar:focus-visible, .open-sidebar:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
 .close-sidebar {
   display: none;
 }

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -41,7 +41,7 @@
           <input type="hidden" name="<%= p %>" value="<%= params[p] %>">
         <% end %>
         <%= render partial: 'shared/locale_override_field' %>
-        <input type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('discussions.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎">
+        <input type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('discussions.search_placeholder') %>" aria-label="<%= t('discussions.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('discussions.search_placeholder') %>">
       </form>
 
       <div id="discussion-list-sort" class="list-option-group"><%= t('scripts.listing_sort_label') %>
@@ -109,8 +109,13 @@
         <ul>
           <%= discussion_list_link(t('discussions.locale_filter.all'), show_locale: nil) %>
           <%= discussion_list_link(request_locale.best_name(in_locale: request_locale), show_locale: request_locale.code) %>
-          <% showing_request_locale = @filter_result.locale && @filter_result.locale == request_locale %>
-          <li class="list-option <%= 'list-current' if @filter_result.locale && !showing_request_locale %>">
+          <% showing_request_locale = @filter_result.locale && @filter_result.locale == request_locale
+          custom_locale_current = @filter_result.locale && !showing_request_locale %>
+          <% if custom_locale_current %>
+            <li class="list-option list-current" aria-current="true">
+          <% else %>
+            <li class="list-option">
+          <% end %>
             <select id="discussion-locale">
               <option></option>
               <% @possible_locales.each do |l| %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,8 +10,8 @@
 <div id="home-script-nav">
   <%= form_tag(scripts_path, class: 'home-search', method: :get) do %>
     <%= render partial: 'shared/locale_override_field' %>
-    <input type="search" name="q" placeholder="<%= t('home.search_placeholder') %>">
-    <input type="submit" value="🔎" class="search-submit">
+    <input type="search" name="q" placeholder="<%= t('home.search_placeholder') %>" aria-label="<%= t('home.search_placeholder') %>">
+    <input type="submit" value="🔎" class="search-submit" aria-label="<%= t('home.search_placeholder') %>">
   <% end %>
   <div id="home-top-sites">
     <%= t('home.scripts_for_label') %>

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -2,7 +2,7 @@
   <h3><%= t('search.script_search.title') %></h3>
   <p><%= it('search.script_search.description') %></p>
 
-  <p><input type="search" name="q" placeholder="Search terms" value="<%= params[:q]%>"></p>
+  <p><input type="search" name="q" placeholder="Search terms" value="<%= params[:q]%>" aria-label="<%= t('search.script_search.title') %>"></p>
 
   <% regular_search_params.except(:q, :site).each do |p, v| %>
     <input type="hidden" name="<%= p %>" value="<%= v %>">
@@ -69,17 +69,17 @@
 <%= form_tag(libraries_scripts_path, id: 'library-search', method: :get) do %>
   <h3><%= t('search.library_search.title') %></h3>
   <p><%= it('search.library_search.description') %></p>
-  <input type="search" name="q"><input class="search-submit" type="submit" value="🔎">
+  <input type="search" name="q" aria-label="<%= t('search.library_search.title') %>"><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('search.library_search.title') %>">
 <% end %>
 
 <%= form_tag(code_search_scripts_path, id: 'code-search', method: :get) do %>
   <h3><%= t('search.code_search.title') %></h3>
   <p><%= t('search.code_search.description') %></p>
-  <input type="search" name="c"><% if current_user&.moderator? %><input id="code-search-include-deleted" type="checkbox" name="include_deleted" value="1"><label for="code-search-include-deleted">Include deleted</label> <% end %><input class="search-submit" type="submit" value="🔎">
+  <input type="search" name="c" aria-label="<%= t('search.code_search.title') %>"><% if current_user&.moderator? %><input id="code-search-include-deleted" type="checkbox" name="include_deleted" value="1"><label for="code-search-include-deleted">Include deleted</label> <% end %><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('search.code_search.title') %>">
 <% end %>
 
 <%= form_tag(users_path, id: 'user-search', method: :get) do %>
   <h3><%= t('search.user_search.title') %></h3>
   <p><%= t('search.user_search.description') %></p>
-  <input type="search" name="q"><input class="search-submit" type="submit" value="🔎">
+  <input type="search" name="q" aria-label="<%= t('search.user_search.title') %>"><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('search.user_search.title') %>">
 <% end %>

--- a/app/views/scripts/_list_options.html.erb
+++ b/app/views/scripts/_list_options.html.erb
@@ -22,7 +22,7 @@ current_options[:rel] = rel if rel
         <% end %>
       <% end %>
       <%= render partial: 'shared/locale_override_field' %>
-      <input type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('scripts.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎">
+      <input type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('scripts.search_placeholder') %>" aria-label="<%= t('scripts.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('scripts.search_placeholder') %>">
     </form>
   <% end %>
 
@@ -115,7 +115,7 @@ current_options[:rel] = rel if rel
   <% if advanced_search_applied? %>
     <div id="script-list-advanced-search" class="list-option-group">
       <ul>
-        <li class="list-option list-current"><%= link_to t('scripts.listing_advanced_search_applied'), search_path(**all_search_params) %></li>
+        <li class="list-option list-current" aria-current="true"><%= link_to t('scripts.listing_advanced_search_applied'), search_path(**all_search_params) %></li>
         <li class="list-option"><%= link_to t('scripts.listing_advanced_search_clear'), current_script_listing_path(**regular_search_params.except(:site)) %></li>
     </div>
   <% end %>

--- a/app/views/scripts/by_site.html.erb
+++ b/app/views/scripts/by_site.html.erb
@@ -5,8 +5,8 @@
 
 <form>
   <label for="filter-by-sites"><%= t('scripts.by_site_list_filter') %></label>
-  <input name="q" type="search" value="<%= params[:q] %>">
-  <input class="search-submit" type="submit" value="🔎">
+  <input id="filter-by-sites" name="q" type="search" value="<%= params[:q] %>">
+  <input class="search-submit" type="submit" value="🔎" aria-label="<%= t('scripts.by_site_list_filter') %>">
 </form>
 
 <ol id="by-site-list">

--- a/app/views/users/_list_options.html.erb
+++ b/app/views/users/_list_options.html.erb
@@ -9,7 +9,7 @@
     <% if params[:banned].present? %>
       <input type="hidden" name="banned" value="<%= params[:banned] %>">
     <% end %>
-    <input id="user-search-field" type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('users.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎">
+    <input id="user-search-field" type="search" name="q" value="<%= params[:q] %>" placeholder="<%= t('users.search_placeholder') %>" aria-label="<%= t('users.search_placeholder') %>"><input class="search-submit" type="submit" value="🔎" aria-label="<%= t('users.search_placeholder') %>">
   <% end %>
 
   <div id="user-list-sort" class="list-option-group"><%= t('scripts.listing_sort_label') %>


### PR DESCRIPTION
## Summary

Improve keyboard and screen reader accessibility across navigation, filters, search controls, and active-state indicators without changing the overall Greasy Fork design.

## Changes

- Make the mobile navigation opener keyboard-operable and expose its expanded/collapsed state with ARIA.
- Add keyboard interaction, focus management, and ARIA state to the mobile sidebar/filter controls.
- Keep the desktop “More” submenu available while keyboard focus is inside it.
- Add visible focus styles for the mobile navigation and sidebar controls.
- Mark current navigation/list/filter items with `aria-current` where appropriate.
- Add accessible names to icon-only and search controls using existing translations.
- Fix the label association for the scripts-by-site filter.
- Improve active-state semantics in Discussions and Advanced Search.

## Validation

- `node --check` passes for the modified JavaScript files.
- Relevant Ruby snippets and ERB templates were syntax-checked.
- Tested locally with Rails + Vite using the project's development environment.
- Manually tested keyboard navigation, Enter/Space activation, Escape handling, focus return, active states, and responsive/mobile behavior in Chrome.

This is intentionally a focused accessibility improvement rather than a visual redesign.