### PR TITLE
Derive locale route constraint from available locales

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   get '/:locale', constraints: { locale: /fr-ca|pt-br|zh-cn|zh-tw/ }, to: lowercase_locale_redirector
   get '/:locale/*', constraints: { locale: /fr-ca|pt-br|zh-cn|zh-tw/ }, to: lowercase_locale_redirector
 
-  scope '(:locale)', locale: /ar|be|bg|ckb|cs|da|de|el|en|es|es-419|fi|fil|fr|fr-CA|he|hr|hu|id|it|ja|ka|ko|mr|nb|nl|eo|pl|pt|pt-BR|ro|ru|sk|sr|sv|th|tr|uk|ug|vi|zh-CN|zh-TW/ do
+  scope '(:locale)', locale: Regexp.union(Rails.application.config.available_locales) do
     get '/users', to: 'users#index', as: 'users'
     get '/users/webhook-info', to: 'users#webhook_info', as: 'user_webhook_info'
     post 'users/webhook-info', to: 'users#webhook_info'


### PR DESCRIPTION
## Summary

Use `Rails.application.config.available_locales` as the source for the localized route constraint instead of maintaining the same locale list separately in `config/routes.rb`.

## Why

Enabled UI locales are explicitly controlled through `Rails.application.config.available_locales`.

The route constraint currently duplicates that list, which means enabling a locale requires updating two separate places and they can become inconsistent.

This change does not automatically enable locales based on the presence of translation files. `available_locales` remains the explicit gate for which locales are enabled.

## Changes

- Replace the hard-coded localized route regex with `Regexp.union(Rails.application.config.available_locales)`.
- Keep the lowercase locale redirect constraint separate, since it only applies to locale codes that require case normalization.

## Validation

- One-line change in `config/routes.rb`.
- The branch is one commit ahead of the current `main`.
- `Regexp.union` safely handles both simple and hyphenated locale codes.
- No intended routing behavior changes for currently enabled locales.