### PR TITLE
Fix new user form border color variable

### DIFF
--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -459,7 +459,7 @@ form.new_user {
   margin: 0 auto;
   padding: 1em;
   background-color: var(--content-background-color);
-  border: 1px solid content(--content-border-color);
+  border: 1px solid var(--content-border-color);
   border-radius: 5px;
   text-align: start;
 }


### PR DESCRIPTION
## Summary

Fix the `form.new_user` border declaration so it uses the existing CSS custom property correctly.

The declaration currently uses `content(--content-border-color)`, which is invalid for `border`. This changes it to `var(--content-border-color)`, matching the surrounding styles and restoring the intended border color.

## Validation

- Change is limited to a single CSS declaration.
- No layout or design changes beyond applying the intended existing border color.