### PR TITLE
Localize empty user list message

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -12,7 +12,7 @@
     </div>
 
     <% if @users.empty? %>
-      <p>No users!</p>
+      <p><%= t('scripts.listing_none') %></p>
     <% else %>
       <ol id="browse-user-list" class="user-list">
         <%= render partial: 'user', collection: @users, locals: {script_counts: @user_script_counts} %>


### PR DESCRIPTION
## Summary

Replace the hard-coded `No users!` empty state on the user listing with the existing localized generic empty-list string.

This removes an English-only UI string without introducing a new translation key or translation churn.

## Validation

- Change is limited to the empty user-list message.
- Reuses the existing `scripts.listing_none` translation, documented as the generic message for a list with nothing to show.