### PR TITLE
Fix redacted email last character

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -82,6 +82,6 @@ module UsersHelper
 
   def redacted_email(email)
     parts = email.split('@', 2)
-    "#{parts[0][0]}…#{parts[0][parts.length - 1]}@#{parts[1]}"
+    "#{parts[0][0]}…#{parts[0][-1]}@#{parts[1]}"
   end
 end

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersHelperTest < ActionView::TestCase
+  test 'redacted email uses the last character of the local part' do
+    assert_equal 'j…n@example.com', redacted_email('john@example.com')
+  end
+end


### PR DESCRIPTION
## Summary

Fix email redaction so it preserves the first and last characters of the email's local part.

`redacted_email` currently indexes the local part using `parts.length - 1`. Since `parts` is the two-element result of splitting on `@`, this selects the second character of the local part rather than its last character.

Using `parts[0][-1]` correctly selects the final character.

## Validation

- Added a helper test covering `john@example.com` → `j…n@example.com`.
- Change is limited to email redaction output.