### PR TITLE
Fix spammy email domain reblock duration

### DIFF
--- a/app/jobs/spammy_email_domain_banner_job.rb
+++ b/app/jobs/spammy_email_domain_banner_job.rb
@@ -30,7 +30,7 @@ class SpammyEmailDomainBannerJob
       sed = SpammyEmailDomain.new(domain:, block_type: SpammyEmailDomain::BLOCK_TYPE_REGISTER, block_count: 1)
     end
 
-    sed.expires_at = (REBLOCKED_MULTIPLIER ^ (sed.block_count - 1)).months.from_now
+    sed.expires_at = (REBLOCKED_MULTIPLIER**(sed.block_count - 1)).months.from_now
     sed.save!
 
     SpammyEmailDomainBannerMailer.banned_confirm(domain, sed.expires_at).deliver_later

--- a/test/jobs/spammy_email_domain_banner_job_test.rb
+++ b/test/jobs/spammy_email_domain_banner_job_test.rb
@@ -19,7 +19,7 @@ class SpammyEmailDomainBannerJobTest < ActiveSupport::TestCase
       SpammyEmailDomainBannerJob.perform_inline('yahoo.com')
     end
     sed = SpammyEmailDomain.find_by!(domain: 'yahoo.com')
-    assert_in_delta 1.month.from_now.to_f, sed.expires_at.to_f, 2
+    assert_equal 1.month.from_now.to_date, sed.expires_at.to_date
   end
 
   test 'matches but no ban if existing old user' do
@@ -61,7 +61,7 @@ class SpammyEmailDomainBannerJobTest < ActiveSupport::TestCase
     assert_no_difference -> { SpammyEmailDomain.count } do
       SpammyEmailDomainBannerJob.perform_inline('yahoo.com')
     end
-    assert_in_delta 2.months.from_now.to_f, sed.reload.expires_at.to_f, 2
+    assert_equal 2.months.from_now.to_date, sed.reload.expires_at.to_date
     assert sed.expires_at.future?
     assert sed.active?
     assert_equal 2, sed.block_count

--- a/test/jobs/spammy_email_domain_banner_job_test.rb
+++ b/test/jobs/spammy_email_domain_banner_job_test.rb
@@ -18,6 +18,8 @@ class SpammyEmailDomainBannerJobTest < ActiveSupport::TestCase
     assert_difference -> { SpammyEmailDomain.count } do
       SpammyEmailDomainBannerJob.perform_inline('yahoo.com')
     end
+    sed = SpammyEmailDomain.find_by!(domain: 'yahoo.com')
+    assert_in_delta 1.month.from_now.to_f, sed.expires_at.to_f, 2
   end
 
   test 'matches but no ban if existing old user' do
@@ -59,7 +61,8 @@ class SpammyEmailDomainBannerJobTest < ActiveSupport::TestCase
     assert_no_difference -> { SpammyEmailDomain.count } do
       SpammyEmailDomainBannerJob.perform_inline('yahoo.com')
     end
-    assert sed.reload.expires_at.future?
+    assert_in_delta 2.months.from_now.to_f, sed.reload.expires_at.to_f, 2
+    assert sed.expires_at.future?
     assert sed.active?
     assert_equal 2, sed.block_count
   end


### PR DESCRIPTION
## Summary

Fix the automatic spammy email-domain block duration calculation.

The job currently uses `^`, which is bitwise XOR in Ruby, while the intended behavior is for the block duration to start at one month and double on each subsequent block.

This can currently produce incorrect durations, including a zero-month duration for some block counts.

Use exponentiation (`**`) so the duration follows the intended 1, 2, 4, 8… month progression.

## Validation

- Added an assertion that the initial automatic block lasts one month.
- Added an assertion that the first reblock lasts two months.