### PR TITLE
Fix conversation latest URL pagination

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -31,7 +31,7 @@ class Conversation < ApplicationRecord
   end
 
   def latest_url(user, locale: nil)
-    pages = (messages.count / 50) + 1
+    pages = ((messages.count - 1) / 50) + 1
     last_message_id = messages.order(:id).last.id
     locale = locale.code if locale.is_a?(Locale)
     Rails.application.routes.url_helpers.user_conversation_url(user, self, locale: locale || user.available_locale_code, page: (pages > 1) ? pages : nil, anchor: "message-#{last_message_id}")

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ConversationTest < ActiveSupport::TestCase
+  test 'latest url stays on the first page with exactly 50 messages' do
+    conversation = conversations(:geoff_and_junior)
+    messages = conversation.messages
+    messages.stubs(:count).returns(50)
+    conversation.stubs(:messages).returns(messages)
+
+    assert_not_includes conversation.latest_url(users(:geoff), locale: 'en'), 'page='
+  end
+
+  test 'latest url uses the second page with 51 messages' do
+    conversation = conversations(:geoff_and_junior)
+    messages = conversation.messages
+    messages.stubs(:count).returns(51)
+    conversation.stubs(:messages).returns(messages)
+
+    assert_includes conversation.latest_url(users(:geoff), locale: 'en'), 'page=2'
+  end
+end


### PR DESCRIPTION
## Summary

Fix an off-by-one error when generating the URL for the latest message in a conversation.

`Conversation#latest_url` currently calculates the page from the total number of messages. At exact page boundaries, such as 50 messages, this incorrectly points to the next page even though the latest message is still on the current page.

Calculate the page based on the zero-based position of the latest message instead.

## Validation

- Added coverage for the 50-message boundary, which should remain on page 1.
- Added coverage for 51 messages, which should correctly point to page 2.