### PR TITLE
Fix repeating spam pattern check

### DIFF
--- a/app/jobs/user_checking_job.rb
+++ b/app/jobs/user_checking_job.rb
@@ -14,6 +14,6 @@ class UserCheckingJob < ApplicationJob
   end
 
   def repeating?(text)
-    text.length == 9 && text[0..2] == text[3..5] && text[6..8]
+    text.length == 9 && text[0..2] == text[3..5] && text[3..5] == text[6..8]
   end
 end

--- a/test/jobs/user_checking_job_test.rb
+++ b/test/jobs/user_checking_job_test.rb
@@ -20,4 +20,12 @@ class UserCheckingJobTest < ActiveSupport::TestCase
       UserCheckingJob.perform_now(user)
     end
   end
+
+  test 'repeating detects three repeated groups' do
+    assert UserCheckingJob.new.repeating?('abcabcabc')
+  end
+
+  test 'repeating rejects a different third group' do
+    assert_not UserCheckingJob.new.repeating?('abcabcdef')
+  end
 end


### PR DESCRIPTION
## Summary

Fix the repeating-pattern check used by `UserCheckingJob`.

The current check verifies that the first three-character block matches the second, but only checks that the third block exists rather than comparing it.

As a result, a value such as `abcabcdef` is incorrectly treated as repeating even though its final block differs.

Compare all three blocks so only patterns such as `abcabcabc` match.

## Validation

- Added a positive test for `abcabcabc`.
- Added a negative test for `abcabcdef`.