### PR TITLE
Fix report moderator action logging

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -115,15 +115,19 @@ class Report < ApplicationRecord
         reported_users.each { |user| user.ban!(moderator:, automod:, delete_comments:, delete_scripts:, ban_related: true, report: self) }
       when Comment
         reported_users.each { |user| user.ban!(moderator:, automod:, delete_comments:, delete_scripts:, ban_related: true, report: self) } if ban_user
-        item.soft_destroy!(by_user: moderator) unless item.soft_deleted?
-        ModeratorAction.create!(moderator:, automod:, comment: item, action_taken: :delete, report: self, private_reason: moderator_notes) unless item.soft_deleted? || ban_user
+        unless item.soft_deleted?
+          item.soft_destroy!(by_user: moderator)
+          ModeratorAction.create!(moderator:, automod:, comment: item, action_taken: :delete, report: self, private_reason: moderator_notes) unless ban_user
+        end
       when Discussion
         if reason == REASON_WRONG_CATEGORY
           item.update!(discussion_category_id:, script_id: nil, rating: nil, title: item.first_comment.plain_text.truncate(200))
         else
           reported_users.each { |user| user.ban!(moderator:, automod:, delete_comments:, delete_scripts:, ban_related: true, report: self) } if ban_user
-          item.soft_destroy!(by_user: moderator) unless item.soft_deleted?
-          ModeratorAction.create!(moderator:, automod:, discussion: item, action_taken: :delete, report: self, private_reason: moderator_notes) unless item.soft_deleted? || ban_user
+          unless item.soft_deleted?
+            item.soft_destroy!(by_user: moderator)
+            ModeratorAction.create!(moderator:, automod:, discussion: item, action_taken: :delete, report: self, private_reason: moderator_notes) unless ban_user
+          end
         end
       when Script
         item.locked = true

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -30,4 +30,30 @@ class ReportTest < ActiveSupport::TestCase
     end
     assert_nil comment.reload.review_reason
   end
+
+  test 'upholding a comment report logs the moderator deletion' do
+    comment = comments(:non_script_comment_2)
+    report = Report.create!(item: comment, reason: Report::REASON_SPAM, reporter: users(:one))
+
+    assert_difference -> { ModeratorAction.where(comment:).count }, 1 do
+      report.uphold!(moderator: users(:mod))
+    end
+
+    action = ModeratorAction.find_by!(comment:)
+    assert_equal report, action.report
+    assert action.action_taken_delete?
+  end
+
+  test 'upholding a discussion report logs the moderator deletion' do
+    discussion = discussions(:non_script_discussion)
+    report = Report.create!(item: discussion, reason: Report::REASON_SPAM, reporter: users(:consumer))
+
+    assert_difference -> { ModeratorAction.where(discussion:).count }, 1 do
+      report.uphold!(moderator: users(:mod))
+    end
+
+    action = ModeratorAction.find_by!(discussion:)
+    assert_equal report, action.report
+    assert action.action_taken_delete?
+  end
 end


### PR DESCRIPTION
## Summary

Fix moderator action logging when upholding a report causes a comment or discussion to be deleted.

`Report#uphold!` currently checks `item.soft_deleted?` again after calling `soft_destroy!`. At that point the item has already been marked as deleted, so the corresponding `ModeratorAction` is never created.

Create the moderation action as part of the same branch that performs the deletion, while continuing to avoid duplicate logging when the item was already deleted or when the deletion is part of a user ban.

## Validation

* Added a regression test confirming that upholding a comment report records the moderator deletion.
* Added a regression test confirming that upholding a discussion report records the moderator deletion.
* Both tests verify that exactly one `ModeratorAction` is created.
* Both tests verify that the action is associated with the originating report and uses the delete action.
