### PR TITLE
Fix comment deletion for related user bans

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -302,7 +302,7 @@ class User < ApplicationRecord
 
     if ban_related
       User.not_banned.where(canonical_email:).find_each do |user|
-        user.ban!(moderator:, automod:, reason:, delete_comments: delete_scripts, delete_scripts:, private_reason:, ban_related: false, report:)
+        user.ban!(moderator:, automod:, reason:, delete_comments:, delete_scripts:, private_reason:, ban_related: false, report:)
       end
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -29,6 +29,32 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'banning related users propagates comment deletion' do
+    user = users(:one)
+    related_user = users(:geoff)
+    related_user.update_columns(canonical_email: user.canonical_email)
+    related_comment = comments(:script_comment)
+    SpammyEmailDomainBannerJob.stubs(:perform_async)
+
+    user.ban!(moderator: users(:mod), delete_comments: true, delete_scripts: false)
+
+    assert related_user.reload.banned?
+    assert related_comment.reload.soft_deleted?
+  end
+
+  test 'banning related users does not derive comment deletion from script deletion' do
+    user = users(:one)
+    related_user = users(:geoff)
+    related_user.update_columns(canonical_email: user.canonical_email)
+    related_comment = comments(:script_comment)
+    SpammyEmailDomainBannerJob.stubs(:perform_async)
+
+    user.ban!(moderator: users(:mod), delete_comments: false, delete_scripts: true)
+
+    assert related_user.reload.banned?
+    assert_not related_comment.reload.soft_deleted?
+  end
+
   test 'blocked_from_reporting_until with no reports' do
     user = users(:one)
     assert_nil user.blocked_from_reporting_until


### PR DESCRIPTION
## Summary

Fix comment deletion propagation when banning related users.

`User#ban!` currently passes `delete_scripts` as the value for `delete_comments` when propagating a ban to related accounts. This causes comment deletion to depend on the script deletion option instead of the requested comment deletion option.

Propagate `delete_comments` independently, matching the options used for the original ban.

## Validation

* Added a regression test confirming that comment deletion is propagated to related users when requested.
* Added a regression test confirming that enabling script deletion does not also delete comments when comment deletion was not requested.
