### PR TITLE
Fix report blocking to use the last five resolved reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -247,7 +247,7 @@ class ReportsController < ApplicationController
     return false if current_user.trusted_reports || current_user.moderator?
 
     # If lots of people have reported the item and it's always dismissed, then block reports on that item for a week.
-    date = item_reporting_blocked_until
+    date = Report.where(item:).reporting_blocked_until
     if date
       render_error(200, It.it('reports.reported_temporarily_blocked', date: I18n.l(date.to_date), rules_link: help_code_rules_path, site_name:))
       return true
@@ -270,11 +270,6 @@ class ReportsController < ApplicationController
     end
 
     false
-  end
-
-  def item_reporting_blocked_until
-    recent_reports = Report.resolved.where(item:, created_at: 1.week.ago..).order(:created_at)
-    recent_reports.first.created_at + 1.week if recent_reports.count(&:dismissed?) == 5
   end
 
   def load_report

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -82,6 +82,13 @@ class Report < ApplicationRecord
   validates :discussion_category, presence: true, if: -> { reason == REASON_WRONG_CATEGORY }
   validates :private_explanation, length: { maximum: 65_535 }
 
+  def self.reporting_blocked_until
+    recent_reports = self.resolved.where(created_at: 1.week.ago..).order(created_at: :desc, id: :desc).limit(5).to_a
+    return unless recent_reports.size == 5 && recent_reports.all?(&:dismissed?)
+
+    recent_reports.last.created_at + 1.week
+  end
+
   def dismiss!(moderator:, moderator_notes:)
     update!(result: RESULT_DISMISSED, moderator_notes:, resolver: moderator)
     if item.is_a?(Discussion) || item.is_a?(Comment)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -463,8 +463,7 @@ class User < ApplicationRecord
   end
 
   def blocked_from_reporting_until
-    recent_reports = reports_as_reporter.resolved.where(created_at: 1.week.ago..).order(:created_at)
-    recent_reports.first.created_at + 1.week if recent_reports.count(&:dismissed?) == 5
+    reports_as_reporter.reporting_blocked_until
   end
 
   def bannable?

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -56,4 +56,27 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal report, action.report
     assert action.action_taken_delete?
   end
+
+  test 'reporting_blocked_until remains blocked after more than five dismissed reports' do
+    user = users(:one)
+    6.times { Report.create!(reporter: user, result: Report::RESULT_DISMISSED, item: Script.first, reason: Report::REASON_SPAM) }
+
+    assert_not_nil user.reports_as_reporter.reporting_blocked_until
+  end
+
+  test 'reporting_blocked_until only considers the last five resolved reports' do
+    user = users(:one)
+    5.times { Report.create!(reporter: user, result: Report::RESULT_DISMISSED, item: Script.first, reason: Report::REASON_SPAM) }
+    Report.create!(reporter: user, result: Report::RESULT_UPHELD, item: Script.first, reason: Report::REASON_SPAM)
+
+    assert_nil user.reports_as_reporter.reporting_blocked_until
+  end
+
+  test 'reporting_blocked_until requires five reports from the last week' do
+    user = users(:one)
+    Report.create!(reporter: user, result: Report::RESULT_DISMISSED, item: Script.first, reason: Report::REASON_SPAM, created_at: 8.days.ago)
+    4.times { Report.create!(reporter: user, result: Report::RESULT_DISMISSED, item: Script.first, reason: Report::REASON_SPAM) }
+
+    assert_nil user.reports_as_reporter.reporting_blocked_until
+  end
 end


### PR DESCRIPTION
## Summary

Fix temporary report blocking so it evaluates the last five resolved reports, matching the original intended behavior.

The current implementation counts dismissed reports within the last week and only blocks when that count is exactly five. This can incorrectly stop blocking after a sixth dismissed report, and can also block when five dismissed reports are followed by a more recent upheld report.

Apply the same last-five logic to both reporter-level blocking and item-level blocking. The five most recent resolved reports must all be dismissed and all be within the last week.

## Validation

* Added regression coverage confirming that more than five consecutive dismissed reports remain blocked.
* Added regression coverage confirming that a more recent upheld report prevents blocking.
* Added regression coverage confirming that the last five resolved reports must all be within the one-week window.
* Covered both reporter-level and item-level report blocking.
