### PR TITLE
Fix favorite script sets returning scripts instead of IDs

### DIFF
--- a/app/models/script_set.rb
+++ b/app/models/script_set.rb
@@ -18,7 +18,7 @@ class ScriptSet < ApplicationRecord
 
     # favorites can only directly include scripts
     if favorite
-      r.merge(child_script_inclusions)
+      r.merge(as_ids ? child_script_inclusions.map(&:id) : child_script_inclusions)
       return r
     end
 

--- a/test/models/script_set_test.rb
+++ b/test/models/script_set_test.rb
@@ -8,6 +8,15 @@ class ScriptSetTest < ActiveSupport::TestCase
     assert_equal [script], set.scripts(:all).to_a
   end
 
+  test 'favorite include returns ids when requested' do
+    set = ScriptSet.new(favorite: true)
+    script = Script.new(id: 123)
+    set.add_child(script)
+
+    assert_equal [script], set.scripts(:all).to_a
+    assert_equal [123], set.scripts(:all, as_ids: true).to_a
+  end
+
   test 'nested include' do
     set1 = ScriptSet.new
     set2 = ScriptSet.new


### PR DESCRIPTION
## Summary

Fix favorite script sets so `ScriptSet#scripts(..., as_ids: true)` consistently returns script IDs.

`ScriptSetsController#index` requests script IDs when serializing script sets to JSON. Regular script sets honor `as_ids: true`, but the special favorite-set path returns early with `Script` objects instead.

Apply the same ID conversion to favorite sets so the method respects its `as_ids` option consistently.

## Validation

* Added a regression test confirming that favorite sets still return `Script` objects by default.
* Added a regression test confirming that favorite sets return script IDs when `as_ids: true` is requested.
