### PR TITLE
Fix all-sites counts for filtered top sites

### DIFF
--- a/app/services/top_sites_service.rb
+++ b/app/services/top_sites_service.rb
@@ -24,7 +24,7 @@ class TopSitesService
         SQL
         Rails.logger.warn('Loading by_sites') if Greasyfork::Application.config.log_cache_misses
         by_sites = Script.connection.select_rows(sql)
-        all_sites = all_sites_count(script_subset:, locale_id:, user_id:).values.to_a
+        all_sites = all_sites_count(script_subset:, locale_id:, user_id:, force: cache_options[:force]).values.to_a
         Rails.logger.warn('Combining by_sites and all_sites') if Greasyfork::Application.config.log_cache_misses
         # combine with "All sites" number
         a = ([[nil] + all_sites] + by_sites)
@@ -44,8 +44,8 @@ class TopSitesService
       end
     end
 
-    def all_sites_count(script_subset: :all, locale_id: nil, user_id: nil)
-      return CachingService.cache_with_log("all_sites_count/#{script_subset}/#{locale_id}/#{user_id}", expires_in: 10.minutes) do
+    def all_sites_count(script_subset: :all, locale_id: nil, user_id: nil, force: false)
+      return CachingService.cache_with_log("all_sites_count/#{script_subset}/#{locale_id}/#{user_id}", expires_in: 10.minutes, force:) do
         filter_clauses = script_filter_clauses(script_subset:, locale_id:, user_id:)
         sql = <<~SQL.squish
           SELECT

--- a/app/services/top_sites_service.rb
+++ b/app/services/top_sites_service.rb
@@ -87,8 +87,6 @@ class TopSitesService
                         'AND `sensitive` = false'
                       when :sleazyfork
                         'AND `sensitive` = true'
-                      else
-                        ''
                       end
       locale_clause = if locale_id
                         "AND s.id IN (#{([0] + LocalizedScriptAttribute.where(locale_id:).distinct.pluck(:script_id)).join(',')})"

--- a/app/services/top_sites_service.rb
+++ b/app/services/top_sites_service.rb
@@ -5,20 +5,7 @@ class TopSitesService
     # Returns a hash, key: site name, value: hash with keys installs, scripts
     def get_by_sites(script_subset:, locale_id: nil, user_id: nil, **cache_options)
       return CachingService.cache_with_log("scripts/get_by_sites/#{script_subset}/#{locale_id}/#{user_id}", cache_options) do
-        subset_clause = case script_subset
-                        when :greasyfork
-                          'AND `sensitive` = false'
-                        when :sleazyfork
-                          'AND `sensitive` = true'
-                        else
-                          ''
-                        end
-        locale_clause = if locale_id
-                          "AND s.id IN (#{([0] + LocalizedScriptAttribute.where(locale_id:).distinct.pluck(:script_id)).join(',')})"
-                        else
-                          ''
-                        end
-        user_clause = ("AND s.id IN (#{([0] + User.find(user_id).script_ids).join(',')})" if user_id)
+        filter_clauses = script_filter_clauses(script_subset:, locale_id:, user_id:)
         sql = <<~SQL.squish
           SELECT
             domain_text, SUM(daily_installs) install_count, COUNT(s.id) script_count
@@ -31,15 +18,13 @@ class TopSitesService
             AND script_type = 1
             AND delete_type IS NULL
             AND !tld_extra
-            #{subset_clause}
-            #{locale_clause}
-            #{user_clause}
+            #{filter_clauses}
           GROUP BY domain_text
           ORDER BY domain_text
         SQL
         Rails.logger.warn('Loading by_sites') if Greasyfork::Application.config.log_cache_misses
         by_sites = Script.connection.select_rows(sql)
-        all_sites = all_sites_count.values.to_a
+        all_sites = all_sites_count(script_subset:, locale_id:, user_id:).values.to_a
         Rails.logger.warn('Combining by_sites and all_sites') if Greasyfork::Application.config.log_cache_misses
         # combine with "All sites" number
         a = ([[nil] + all_sites] + by_sites)
@@ -59,16 +44,18 @@ class TopSitesService
       end
     end
 
-    def all_sites_count
-      return CachingService.cache_with_log('all_sites_count', expires_in: 10.minutes) do
+    def all_sites_count(script_subset: :all, locale_id: nil, user_id: nil)
+      return CachingService.cache_with_log("all_sites_count/#{script_subset}/#{locale_id}/#{user_id}", expires_in: 10.minutes) do
+        filter_clauses = script_filter_clauses(script_subset:, locale_id:, user_id:)
         sql = <<~SQL.squish
           SELECT
-            sum(daily_installs) install_count, count(distinct scripts.id) script_count
-          FROM scripts
+            sum(daily_installs) install_count, count(distinct s.id) script_count
+          FROM scripts s
           WHERE
             script_type = 1
             AND delete_type is null
-            AND NOT EXISTS (SELECT * FROM script_applies_tos WHERE script_id = scripts.id)
+            #{filter_clauses}
+            AND NOT EXISTS (SELECT * FROM script_applies_tos WHERE script_id = s.id)
         SQL
         Script.connection.select_all(sql).first
       end
@@ -90,6 +77,24 @@ class TopSitesService
           TopSitesService.get_by_sites(script_subset:, locale_id:, force: true)
         end
       end
+    end
+
+    private
+
+    def script_filter_clauses(script_subset:, locale_id:, user_id:)
+      subset_clause = case script_subset
+                      when :greasyfork
+                        'AND `sensitive` = false'
+                      when :sleazyfork
+                        'AND `sensitive` = true'
+                      else
+                        ''
+                      end
+      locale_clause = if locale_id
+                        "AND s.id IN (#{([0] + LocalizedScriptAttribute.where(locale_id:).distinct.pluck(:script_id)).join(',')})"
+                      end
+      user_clause = ("AND s.id IN (#{([0] + User.find(user_id).script_ids).join(',')})" if user_id)
+      [subset_clause, locale_clause, user_clause].compact.join(' ')
     end
   end
 end

--- a/app/services/top_sites_service.rb
+++ b/app/services/top_sites_service.rb
@@ -88,9 +88,7 @@ class TopSitesService
                       when :sleazyfork
                         'AND `sensitive` = true'
                       end
-      locale_clause = if locale_id
-                        "AND s.id IN (#{([0] + LocalizedScriptAttribute.where(locale_id:).distinct.pluck(:script_id)).join(',')})"
-                      end
+      locale_clause = "AND s.id IN (#{([0] + LocalizedScriptAttribute.where(locale_id:).distinct.pluck(:script_id)).join(',')})" if locale_id
       user_clause = ("AND s.id IN (#{([0] + User.find(user_id).script_ids).join(',')})" if user_id)
       [subset_clause, locale_clause, user_clause].compact.join(' ')
     end

--- a/test/services/top_sites_service_test.rb
+++ b/test/services/top_sites_service_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class TopSitesServiceTest < ActiveSupport::TestCase
-  setup do
-    Rails.cache.clear
-  end
-
   test 'get_by_sites' do
     assert_no_error_reported do
       TopSitesService.get_by_sites(script_subset: :greasyfork)

--- a/test/services/top_sites_service_test.rb
+++ b/test/services/top_sites_service_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TopSitesServiceTest < ActiveSupport::TestCase
+  setup do
+    Rails.cache.clear
+  end
+
   test 'get_by_sites' do
     assert_no_error_reported do
       TopSitesService.get_by_sites(script_subset: :greasyfork)
@@ -17,6 +21,46 @@ class TopSitesServiceTest < ActiveSupport::TestCase
     assert_no_error_reported do
       TopSitesService.get_by_sites(script_subset: :greasyfork, user_id: User.first.id)
     end
+  end
+
+  test 'get_by_sites filters all-sites stats by subset' do
+    scripts(:one).update_columns(sensitive: true, daily_installs: 7)
+    scripts(:two).update_columns(sensitive: false, daily_installs: 11)
+
+    greasy_scripts = Script.where(script_type: :public, delete_type: nil, sensitive: false).for_all_sites
+    sleazy_scripts = Script.where(script_type: :public, delete_type: nil, sensitive: true).for_all_sites
+    greasy_expected = { installs: greasy_scripts.sum(:daily_installs), scripts: greasy_scripts.count }
+    sleazy_expected = { installs: sleazy_scripts.sum(:daily_installs), scripts: sleazy_scripts.count }
+
+    assert_predicate greasy_expected[:installs], :positive?
+    assert_predicate greasy_expected[:scripts], :positive?
+    assert_predicate sleazy_expected[:installs], :positive?
+    assert_predicate sleazy_expected[:scripts], :positive?
+    assert_equal greasy_expected, TopSitesService.get_by_sites(script_subset: :greasyfork, force: true).fetch(nil)
+    assert_equal sleazy_expected, TopSitesService.get_by_sites(script_subset: :sleazyfork, force: true).fetch(nil)
+  end
+
+  test 'get_by_sites filters all-sites stats by locale' do
+    locale = locales(:french)
+    scripts(:synced_and_localized).update_column(:daily_installs, 13)
+    script_ids = LocalizedScriptAttribute.where(locale:).distinct.select(:script_id)
+    scripts = Script.where(id: script_ids, script_type: :public, delete_type: nil, sensitive: false).for_all_sites
+    expected = { installs: scripts.sum(:daily_installs), scripts: scripts.count }
+
+    assert_predicate expected[:installs], :positive?
+    assert_predicate expected[:scripts], :positive?
+    assert_equal expected, TopSitesService.get_by_sites(script_subset: :greasyfork, locale_id: locale.id, force: true).fetch(nil)
+  end
+
+  test 'get_by_sites filters all-sites stats by user' do
+    user = users(:consumer)
+    scripts(:derivative_with_same_name).update_column(:daily_installs, 17)
+    scripts = user.scripts.where(script_type: :public, delete_type: nil, sensitive: false).for_all_sites
+    expected = { installs: scripts.sum(:daily_installs), scripts: scripts.count }
+
+    assert_predicate expected[:installs], :positive?
+    assert_predicate expected[:scripts], :positive?
+    assert_equal expected, TopSitesService.get_by_sites(script_subset: :greasyfork, user_id: user.id, force: true).fetch(nil)
   end
 
   test 'get_top_by_sites' do


### PR DESCRIPTION
## Summary

`TopSitesService#get_by_sites` applies `script_subset`, `locale_id`, and `user_id` to site-specific rows, but then combines them with a global `all_sites_count`. As a result, the **All sites** entry can use counts/install totals from scripts outside the current subset, locale, or author filter, which also affects whether it appears among the top-site links.

This is especially inconsistent with the historical intent from #255 / `d025cdacd96d6677430edaedd67092b98356e5f7` (“Top sites should reflect locale and user”).

Apply the same filters to `all_sites_count`, include those dimensions in its cache key, and share the filter-clause construction so the normal-site and all-sites queries cannot drift independently.

## Validation

- Added service-level regression coverage for script subset filtering of All sites stats.
- Added service-level regression coverage for locale filtering of All sites stats.
- Added service-level regression coverage for user/author filtering of All sites stats.
- Local execution was not available in the audit environment: it has Ruby 3.3.8 and no Bundler, while this repository currently requires Ruby 4.0.1. No claim is made that tests or RuboCop passed locally.