### PR TITLE
Enforce script lock appeal checks on submission

### DIFF
--- a/app/controllers/script_lock_appeals_controller.rb
+++ b/app/controllers/script_lock_appeals_controller.rb
@@ -7,6 +7,7 @@ class ScriptLockAppealsController < ApplicationController
   before_action :load_script_lock_appeal, only: [:show, :dismiss, :unlock]
   before_action :authorize_by_script_id, only: [:new, :create]
   before_action :ensure_locked, only: [:new, :create]
+  before_action :ensure_no_open_appeal, only: [:new, :create]
   before_action :authorize_for_moderators_only, only: [:dismiss, :unlock]
 
   before_action do
@@ -20,18 +21,11 @@ class ScriptLockAppealsController < ApplicationController
   def show; end
 
   def new
-    open_appeal = @script.script_lock_appeals.unresolved.first
-    if open_appeal
-      flash[:notice] = t('appeals.already_open')
-      redirect_to script_script_lock_appeal_path(@script, open_appeal)
-      return
-    end
-
-    @script_lock_appeal = @script.script_lock_appeals.build(report_id: @script.report_that_deleted&.id)
+    @script_lock_appeal = @script.script_lock_appeals.build
   end
 
   def create
-    @script_lock_appeal = @script.script_lock_appeals.create!(script_lock_appeal_params)
+    @script_lock_appeal = @script.script_lock_appeals.create!(script_lock_appeal_params.merge(report: @script.report_that_deleted))
     redirect_to script_path(@script), flash: { notice: t('appeals.submitted') }
   end
 
@@ -80,7 +74,14 @@ class ScriptLockAppealsController < ApplicationController
     render_404('Script is not locked.') unless @script.locked?
   end
 
+  def ensure_no_open_appeal
+    open_appeal = @script.script_lock_appeals.unresolved.first
+    return unless open_appeal
+
+    redirect_to script_script_lock_appeal_path(@script, open_appeal), flash: { notice: t('appeals.already_open') }
+  end
+
   def script_lock_appeal_params
-    params.expect(script_lock_appeal: [:text, :text_markup, :report_id])
+    params.expect(script_lock_appeal: [:text, :text_markup])
   end
 end

--- a/app/views/script_lock_appeals/new.html.erb
+++ b/app/views/script_lock_appeals/new.html.erb
@@ -11,6 +11,5 @@
       f.text_area :text, required: true, maxlength: 10_000
     end %>
   </div>
-  <%= f.hidden_field :report_id %>
   <%= f.submit t('appeals.new.submit') %>
 <% end %>


### PR DESCRIPTION
A script lock appeal currently checks for an existing unresolved appeal only when rendering the new form, so a direct POST can bypass that rule. The form also sends report_id back as a hidden field even though the relevant report can be derived from the locked script.

This applies the existing open-appeal check to both new and create, derives the report from Script#report_that_deleted during creation, and removes report_id from the submitted parameters.

Regression coverage verifies that a submitted unrelated report_id is ignored and that a direct POST cannot create a second unresolved appeal. The existing system test continues to cover normal appeal creation.

Local Rails execution was not available in my environment (Ruby 3.3.8/no Bundler while the project requires Ruby 4.0.1), so I have not claimed local test or RuboCop results; fork CI can provide the runtime verification.