### PR TITLE
Force UTF-8 encoding on downloaded additional info

### DIFF
--- a/lib/script_importer/base_script_importer.rb
+++ b/lib/script_importer/base_script_importer.rb
@@ -56,6 +56,11 @@ module ScriptImporter
 
         begin
           ai = ScriptSyncer.choose_importer.download(la.sync_identifier)
+          # PublicHttpFetcher returns ASCII-8BIT strings. Normalize to UTF-8 like the script
+          # code above, or UTF-8 regexps in validations will refuse to match the value.
+          ai = ai.dup if ai.frozen?
+          ai = ai.force_encoding(Encoding::UTF_8)
+          next unless ai.valid_encoding?
           # We don't have the ability to adjust the Markdown to absolutize the references, so we do that at render time.
           if la.value_markup == 'html'
             absolute_ai = absolutize_references(ai, la.sync_identifier)

--- a/test/integration/script_syncer_test.rb
+++ b/test/integration/script_syncer_test.rb
@@ -108,6 +108,27 @@ class ScriptSyncerTest < ActiveSupport::TestCase
     assert_not_nil fr_ai.sync_identifier
   end
 
+  test 'synced additional info is treated as UTF-8' do
+    script = Script.find(14)
+    assert_equal 1, script.script_versions.length
+
+    # PublicHttpFetcher returns ASCII-8BIT strings, unlike the open-uri downloader it
+    # replaced. A binary-tagged additional info used to crash sync with
+    # "incompatible encoding regexp match (UTF-8 regexp with BINARY (ASCII-8BIT) string)"
+    # in the Private Use Area validation. Tag the sync identifier as binary to mimic
+    # what PublicHttpFetcher hands to generate_script; TestImporter returns it unchanged.
+    en_la = script.localized_attributes_for('additional_info')
+                  .find { |la| la.locale == Locale.where(code: 'en').first }
+    en_la.sync_identifier = en_la.sync_identifier.dup.force_encoding(Encoding::ASCII_8BIT)
+
+    assert_equal :success, ScriptSyncer.sync(script), script.sync_error
+
+    en_ai = script.localized_attributes_for('additional_info').find { |la| la.locale == Locale.where(code: 'en').first }
+    assert_not_nil en_ai
+    assert_equal 'MyNewText', en_ai.attribute_value
+    assert_equal Encoding::UTF_8, en_ai.attribute_value.encoding
+  end
+
   test 'additional info sync retain unsynced' do
     script = Script.find(14)
     assert script.valid?, script.errors.full_messages


### PR DESCRIPTION
## Summary

Fixes #issue1585

Since #1581 ("Validate outbound HTTP destinations"), syncing a script whose **additional info** is synced from a URL fails on every attempt with:

> incompatible encoding regexp match (UTF-8 regexp with BINARY (ASCII-8BIT) string)

`PublicHttpFetcher` (SsrfFilter/Net::HTTP) returns bodies tagged ASCII-8BIT, unlike the open-uri downloader it replaced, which tagged them with the response charset (UTF-8 for the usual raw sources). `generate_script` re-tags the downloaded **script code** to UTF-8, but not the downloaded **additional info** (`ai`). That value is stored as a localized attribute, and `Script`'s Private Use Area validation (`/[\u{e000}-\u{f8ff}\u{f0000}-\u{10ffff}]/` — a UTF-8 regexp) then raises `ArgumentError` on the encoding mismatch. The exception escapes `generate_script`, is recorded as the script's sync error, and breaks every sync of any script with additional info URL sync configured until that sync is turned off.

## Change

Normalize the downloaded additional info the same way the script code already is: `dup` if frozen, `force_encoding(Encoding::UTF_8)`, and skip the value if it turns out to be invalid UTF-8 (consistent with this block's existing "ignore failed additional info" behavior).

## Test

`synced additional info is treated as UTF-8` stubs `TestImporter.download` to return an ASCII-8BIT-tagged string for the synced additional info and asserts the sync succeeds with a UTF-8-tagged stored value. Without the change, the sync fails with the ArgumentError above (existing tests miss this because `TestImporter.download` normally returns a UTF-8 string literal).

Note: I could not run the Rails suite locally; CI should validate.